### PR TITLE
Added Usercontext to Export Function CSV

### DIFF
--- a/PowerHuntShares.psm1
+++ b/PowerHuntShares.psm1
@@ -1498,6 +1498,7 @@ function Invoke-HuntSMBShares
         #Write-Output " [*][$Time] Get-ShareInventory Summary Report"
         #Write-Output " [*][$Time] -----------------------------------------------"
         Write-Output " [*][$Time] Domain: $TargetDomain"
+        Write-Output " [*][$Time] User: $Username"
         Write-Output " [*][$Time] Start time: $StartTime"
         Write-Output " [*][$Time] End time: $EndTime"
         Write-Output " [*][$Time] Run time: $RunTime"
@@ -4215,6 +4216,8 @@ $FileList
 Target Domain: $TargetDomain
 
 Scan Summary
+Domain: $TargetDomain
+User: $Username
 Start Time: $StartTime
 End Time: $EndTime
 Run Time: $RunTime


### PR DESCRIPTION
In the Export Function CSV, added user context when importing into reporting platforms.

Changed from
```
Scan Summary
Start Time: xx/xx/xxxx xx:xx:xx
End Time: xx/xx/xxxx xx:xx:xx
Run Time: xx:xx:xx.xxxxxx
```

to 

```
Scan Summary
Domain: xxxxx.xxx
User: xxxxxx
Start Time: xx/xx/xxxx xx:xx:xx
End Time: xx/xx/xxxx xx:xx:xx
Run Time: xx:xx:xx.xxxxxx
```